### PR TITLE
Change "ArchiveStatus" to "ArchiveDatabase" & "ArchiveGuid"

### DIFF
--- a/set_mailbox_quota.ps1
+++ b/set_mailbox_quota.ps1
@@ -41,7 +41,7 @@ foreach ($mailbox in $allMailboxes) {
     $archiveDatabase = (Get-Mailbox -Identity $mailbox).ArchiveDatabase
     $archiveGuid = (Get-Mailbox -Identity $mailbox).ArchiveGuid
 
-    if (($archiveGuid -ne "00000000-0000-0000-0000-000000000000") -and ($archiveDatabase)) {
+    if (($archiveGuid -ne "00000000-0000-0000-0000-000000000000") -and $archiveDatabase) {
         $archiveSize =
             Get-MailboxStatistics -Identity $mailbox -Archive | `
             select @{


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/office365/troubleshoot/archive-mailboxes/archivestatus-set-none, "ArchiveDatabase" and "ArchiveGuid" should be used instead of "ArchiveStatus" to verify the existence of archive mailboxes.